### PR TITLE
Send SMS as `unicode` if message have unicode symbols

### DIFF
--- a/nexmomessage.py
+++ b/nexmomessage.py
@@ -70,6 +70,9 @@ class NexmoMessage:
     def set_text_info(self, text):
         # automatically transforms msg to text SMS
         self.sms['type'] = 'text'
+        # if message is unicode send as unicode
+        if isinstance(text, unicode):
+            self.sms['type'] = 'unicode'
         self.sms['text'] = text
 
     def set_bin_info(self, body, udh):


### PR DESCRIPTION
If SMS message has unicode symbols, they send as '?' instead unicode symbol. Example: http://d.pr/i/2dnO
