### PR TITLE
Allow unicode type values

### DIFF
--- a/nexmomessage/nexmo.py
+++ b/nexmomessage/nexmo.py
@@ -77,7 +77,8 @@ class NexmoMessage:
             text.decode('ascii')
         except:
             self.sms['type'] = 'unicode'
-            self.sms['text'] = unicode(text, 'utf8').encode('utf8')
+            if isinstance(text, unicode):
+                text = text.encode('utf8')
         self.sms['text'] = text
 
     def set_bin_info(self, body, udh):


### PR DESCRIPTION
Fix issue with passing `unicode` values.

```
>>> unicode(u"À", "utf-8").encode("utf-8")
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
TypeError: decoding Unicode is not supported
```
